### PR TITLE
Remove version from composer.json as per documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "vinhhoang/oauth2-azure",
-	"version": "1.0.1",
     "description": "Oauth2 Azure login",
     "license": "MIT",
     "keywords": ["php", "azure"],


### PR DESCRIPTION
The latest two versions are missing from packagist (1.0.1 being the latest). This pull request removes the version from the composer.json file as per here: https://getcomposer.org/doc/04-schema.md#version

The documentation claims this to be unnecessary now as it is inferred by the git tag. Once this is merged, it'd be appreciated if you could tag a v1.0.4

Many thanks for the great package :)